### PR TITLE
 Add common SassDoc themes keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "sassdoc-theme-flippant",
   "version": "0.1.0",
   "description": "A modified version of Sassdoc's default theme",
+  "keywords": [
+    "sassdoc-theme"  
+  ],
   "files": [
     "assets",
     "views",


### PR DESCRIPTION
Greetings,

nice theme.
Would you mind adding that keyword we try to use in every SassDoc themes, so that it's easier to list them on npm ?

https://www.npmjs.com/browse/keyword/sassdoc-theme
